### PR TITLE
Fixing some possible compiler warnings

### DIFF
--- a/Drivers/STM32F2xx_HAL_Driver/Inc/stm32f2xx_hal_def.h
+++ b/Drivers/STM32F2xx_HAL_Driver/Inc/stm32f2xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
-#define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#ifndef UNUSED
+	#define UNUSED(x) (void)(x)  /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_gpio.c
+++ b/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_gpio.c
@@ -104,6 +104,9 @@
   ******************************************************************************
   */
 
+/*Ignore compiler warnings */
+#pragma GCC diagnostic ignored "-Wsign-compare"
+
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f2xx_hal.h"
 

--- a/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_spi.c
+++ b/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_spi.c
@@ -197,6 +197,8 @@
   *
   ******************************************************************************
   */
+/*Ignore compiler warnings */
+#pragma GCC diagnostic ignored "-Wcast-align"
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f2xx_hal.h"

--- a/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_uart.c
+++ b/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_uart.c
@@ -252,6 +252,8 @@
   *
   ******************************************************************************
   */
+/*Ignore compiler warnings */
+#pragma GCC diagnostic ignored "-Wcast-align"
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f2xx_hal.h"

--- a/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_usart.c
+++ b/Drivers/STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_usart.c
@@ -194,6 +194,9 @@
   *
   ******************************************************************************
   */
+/*Ignore compiler warnings */
+#pragma GCC diagnostic ignored "-Wcast-align"
+
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f2xx_hal.h"

--- a/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/CDC/Src/usbd_cdc.c
@@ -58,6 +58,7 @@ EndBSPDependencies */
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_cdc.h"
 #include "usbd_ctlreq.h"
+#pragma GCC diagnostic ignored "-Wredundant-decls"
 
 
 /** @addtogroup STM32_USB_DEVICE_LIBRARY
@@ -470,6 +471,8 @@ __ALIGN_BEGIN uint8_t USBD_CDC_OtherSpeedCfgDesc[USB_CDC_CONFIG_DESC_SIZ] __ALIG
   */
 static uint8_t  USBD_CDC_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
+  UNUSED(cfgidx);
+
   uint8_t ret = 0U;
   USBD_CDC_HandleTypeDef   *hcdc;
 
@@ -548,6 +551,8 @@ static uint8_t  USBD_CDC_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
   */
 static uint8_t  USBD_CDC_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
+  UNUSED(cfgidx);
+
   uint8_t ret = 0U;
 
   /* Close EP IN */

--- a/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Core/Src/usbd_ctlreq.c
@@ -852,6 +852,7 @@ void USBD_ParseSetupRequest(USBD_SetupReqTypedef *req, uint8_t *pdata)
 void USBD_CtlError(USBD_HandleTypeDef *pdev,
                    USBD_SetupReqTypedef *req)
 {
+  UNUSED(req);
   USBD_LL_StallEP(pdev, 0x80U);
   USBD_LL_StallEP(pdev, 0U);
 }


### PR DESCRIPTION
Some fixes to avoid compiler warnings I stumbled upon
- Fixed redefine (UNUSED) warning 
- Fixed unused warnings in USB_DEVICE_LIB 
- Added some compiler warning ignores.  


## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF2/blob/master/CONTRIBUTING.md) file.
