### PR TITLE
Change USART_BRR_DIV_Fraction, USART_BRR_DIV_Mantissa to all CAPS.

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f205xx.h
+++ b/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f205xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -11623,12 +11623,12 @@ USB_OTG_HostChannelTypeDef;
 #define USART_DR_DR                   USART_DR_DR_Msk                          /*!<Data value */
 
 /******************  Bit definition for USART_BRR register  *******************/
-#define USART_BRR_DIV_Fraction_Pos    (0U)                                     
-#define USART_BRR_DIV_Fraction_Msk    (0xFUL << USART_BRR_DIV_Fraction_Pos)     /*!< 0x0000000F */
-#define USART_BRR_DIV_Fraction        USART_BRR_DIV_Fraction_Msk               /*!<Fraction of USARTDIV */
-#define USART_BRR_DIV_Mantissa_Pos    (4U)                                     
-#define USART_BRR_DIV_Mantissa_Msk    (0xFFFUL << USART_BRR_DIV_Mantissa_Pos)   /*!< 0x0000FFF0 */
-#define USART_BRR_DIV_Mantissa        USART_BRR_DIV_Mantissa_Msk               /*!<Mantissa of USARTDIV */
+#define USART_BRR_DIV_FRACTION_Pos    (0U)                                     
+#define USART_BRR_DIV_FRACTION_Msk    (0xFUL << USART_BRR_DIV_FRACTION_Pos)     /*!< 0x0000000F */
+#define USART_BRR_DIV_FRACTION        USART_BRR_DIV_FRACTION_Msk               /*!<Fraction of USARTDIV */
+#define USART_BRR_DIV_MANTISSA_Pos    (4U)                                     
+#define USART_BRR_DIV_MANTISSA_Msk    (0xFFFUL << USART_BRR_DIV_MANTISSA_Pos)   /*!< 0x0000FFF0 */
+#define USART_BRR_DIV_MANTISSA        USART_BRR_DIV_MANTISSA_Msk               /*!<Mantissa of USARTDIV */
 
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_SBK_Pos             (0U)                                     

--- a/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f207xx.h
+++ b/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f207xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -11962,12 +11962,12 @@ USB_OTG_HostChannelTypeDef;
 #define USART_DR_DR                   USART_DR_DR_Msk                          /*!<Data value */
 
 /******************  Bit definition for USART_BRR register  *******************/
-#define USART_BRR_DIV_Fraction_Pos    (0U)                                     
-#define USART_BRR_DIV_Fraction_Msk    (0xFUL << USART_BRR_DIV_Fraction_Pos)     /*!< 0x0000000F */
-#define USART_BRR_DIV_Fraction        USART_BRR_DIV_Fraction_Msk               /*!<Fraction of USARTDIV */
-#define USART_BRR_DIV_Mantissa_Pos    (4U)                                     
-#define USART_BRR_DIV_Mantissa_Msk    (0xFFFUL << USART_BRR_DIV_Mantissa_Pos)   /*!< 0x0000FFF0 */
-#define USART_BRR_DIV_Mantissa        USART_BRR_DIV_Mantissa_Msk               /*!<Mantissa of USARTDIV */
+#define USART_BRR_DIV_FRACTION_Pos    (0U)                                     
+#define USART_BRR_DIV_FRACTION_Msk    (0xFUL << USART_BRR_DIV_FRACTION_Pos)     /*!< 0x0000000F */
+#define USART_BRR_DIV_FRACTION        USART_BRR_DIV_FRACTION_Msk               /*!<Fraction of USARTDIV */
+#define USART_BRR_DIV_MANTISSA_Pos    (4U)                                     
+#define USART_BRR_DIV_MANTISSA_Msk    (0xFFFUL << USART_BRR_DIV_MANTISSA_Pos)   /*!< 0x0000FFF0 */
+#define USART_BRR_DIV_MANTISSA        USART_BRR_DIV_MANTISSA_Msk               /*!<Mantissa of USARTDIV */
 
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_SBK_Pos             (0U)                                     

--- a/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f215xx.h
+++ b/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f215xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -11878,12 +11878,12 @@ USB_OTG_HostChannelTypeDef;
 #define USART_DR_DR                   USART_DR_DR_Msk                          /*!<Data value */
 
 /******************  Bit definition for USART_BRR register  *******************/
-#define USART_BRR_DIV_Fraction_Pos    (0U)                                     
-#define USART_BRR_DIV_Fraction_Msk    (0xFUL << USART_BRR_DIV_Fraction_Pos)     /*!< 0x0000000F */
-#define USART_BRR_DIV_Fraction        USART_BRR_DIV_Fraction_Msk               /*!<Fraction of USARTDIV */
-#define USART_BRR_DIV_Mantissa_Pos    (4U)                                     
-#define USART_BRR_DIV_Mantissa_Msk    (0xFFFUL << USART_BRR_DIV_Mantissa_Pos)   /*!< 0x0000FFF0 */
-#define USART_BRR_DIV_Mantissa        USART_BRR_DIV_Mantissa_Msk               /*!<Mantissa of USARTDIV */
+#define USART_BRR_DIV_FRACTION_Pos    (0U)                                     
+#define USART_BRR_DIV_FRACTION_Msk    (0xFUL << USART_BRR_DIV_FRACTION_Pos)     /*!< 0x0000000F */
+#define USART_BRR_DIV_FRACTION        USART_BRR_DIV_FRACTION_Msk               /*!<Fraction of USARTDIV */
+#define USART_BRR_DIV_MANTISSA_Pos    (4U)                                     
+#define USART_BRR_DIV_MANTISSA_Msk    (0xFFFUL << USART_BRR_DIV_MANTISSA_Pos)   /*!< 0x0000FFF0 */
+#define USART_BRR_DIV_MANTISSA        USART_BRR_DIV_MANTISSA_Msk               /*!<Mantissa of USARTDIV */
 
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_SBK_Pos             (0U)                                     

--- a/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f217xx.h
+++ b/Drivers/CMSIS/Device/ST/STM32F2xx/Include/stm32f217xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -12217,12 +12217,12 @@ USB_OTG_HostChannelTypeDef;
 #define USART_DR_DR                   USART_DR_DR_Msk                          /*!<Data value */
 
 /******************  Bit definition for USART_BRR register  *******************/
-#define USART_BRR_DIV_Fraction_Pos    (0U)                                     
-#define USART_BRR_DIV_Fraction_Msk    (0xFUL << USART_BRR_DIV_Fraction_Pos)     /*!< 0x0000000F */
-#define USART_BRR_DIV_Fraction        USART_BRR_DIV_Fraction_Msk               /*!<Fraction of USARTDIV */
-#define USART_BRR_DIV_Mantissa_Pos    (4U)                                     
-#define USART_BRR_DIV_Mantissa_Msk    (0xFFFUL << USART_BRR_DIV_Mantissa_Pos)   /*!< 0x0000FFF0 */
-#define USART_BRR_DIV_Mantissa        USART_BRR_DIV_Mantissa_Msk               /*!<Mantissa of USARTDIV */
+#define USART_BRR_DIV_FRACTION_Pos    (0U)                                     
+#define USART_BRR_DIV_FRACTION_Msk    (0xFUL << USART_BRR_DIV_FRACTION_Pos)     /*!< 0x0000000F */
+#define USART_BRR_DIV_FRACTION        USART_BRR_DIV_FRACTION_Msk               /*!<Fraction of USARTDIV */
+#define USART_BRR_DIV_MANTISSA_Pos    (4U)                                     
+#define USART_BRR_DIV_MANTISSA_Msk    (0xFFFUL << USART_BRR_DIV_MANTISSA_Pos)   /*!< 0x0000FFF0 */
+#define USART_BRR_DIV_MANTISSA        USART_BRR_DIV_MANTISSA_Msk               /*!<Mantissa of USARTDIV */
 
 /******************  Bit definition for USART_CR1 register  *******************/
 #define USART_CR1_SBK_Pos             (0U)                                     


### PR DESCRIPTION
Other STM32Cube packages have all caps. Changed for better compatibility between different STM32 devices using HAL.