### PR TITLE
Endpoint 0 is stalled if an invalid descriptor type is specified in a…

### DIFF
--- a/Middlewares/ST/STM32_USB_Device_Library/Class/CustomHID/Src/usbd_customhid.c
+++ b/Middlewares/ST/STM32_USB_Device_Library/Class/CustomHID/Src/usbd_customhid.c
@@ -500,7 +500,15 @@ static uint8_t  USBD_CUSTOM_HID_Setup(USBD_HandleTypeDef *pdev,
             }
           }
 
-          USBD_CtlSendData(pdev, pbuf, len);
+          if (pbuf)
+          {
+            USBD_CtlSendData(pdev, pbuf, len);
+          }
+          else
+          {
+            USBD_CtlError(pdev, req);
+            ret = USBD_FAIL;
+          }
           break;
 
         case USB_REQ_GET_INTERFACE :


### PR DESCRIPTION
… standard USB get descriptor request to the HID interface.

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the [CONTRIBUTING.md](https://github.com/STMicroelectronics/STM32CubeF2/blob/master/CONTRIBUTING.md) file.
